### PR TITLE
Melhorias para devcontainer funcionar

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,12 @@ RUN mkdir -p /deno \
 ENV PATH=${DENO_INSTALL}/bin:${PATH} \
     DENO_DIR=${DENO_INSTALL}/.cache/deno
 
+# layouts.download.codeBox.installsNvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# layouts.download.codeBox.downloadAndInstallNodejsRestartTerminal
+RUN nvm install 20
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #    && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,9 @@
 ARG VARIANT=bullseye
 FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:0-${VARIANT}
 
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
+    apt install -y git
+
 ENV DENO_INSTALL=/deno
 RUN mkdir -p /deno \
     && curl -fsSL https://deno.land/x/install/install.sh | sh \
@@ -10,12 +13,11 @@ RUN mkdir -p /deno \
 ENV PATH=${DENO_INSTALL}/bin:${PATH} \
     DENO_DIR=${DENO_INSTALL}/.cache/deno
 
+ENV NVM_DIR="/nvm"
+
 # layouts.download.codeBox.installsNvm
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+RUN mkdir /nvm && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 
-# layouts.download.codeBox.downloadAndInstallNodejsRestartTerminal
-RUN nvm install 20
+SHELL [ "/bin/bash", "-c" ]
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#    && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN source ${NVM_DIR}/nvm.sh && nvm install --lts

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,12 +22,14 @@
 			"extensions": [
 				"denoland.vscode-deno",
 				"Vue.volar",
-				"astro-build.astro-vscode"
+				"astro-build.astro-vscode",
+				"ms-azuretools.vscode-docker"
 			]
 		}
 	},
 
 	"onCreateCommand": "deno upgrade",
+	"postAttachCommand": "echo 'source /nvm/nvm.sh' >> /home/vscode/.bashrc",
 
 	"remoteUser": "vscode"
 }

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -21,6 +21,6 @@ const app = new Application();
 app.use(router.routes());
 app.use(router.allowedMethods());
 
-const opt = { hostname: "localhost", port: 5000 };
+const opt = { hostname: "0.0.0.0", port: 5000 };
 await app.listen(opt);
 console.log(`Starting ${opt}`);

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -4,6 +4,8 @@ dist/
 # generated types
 .astro/
 
+.vercel/
+
 # dependencies
 node_modules/
 

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -7,6 +7,7 @@ import vue from "@astrojs/vue";
 
 // https://astro.build/config
 export default defineConfig({
+  server: { port: 4321, host: "0.0.0.0" },
   integrations: [tailwind(), vue()],
   output: "server",
   adapter: vercel({

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "deno run -A npm:astro dev",
-    "start": "deno run -A --allow-env npm:astro dev",
+    "dev": "astro dev",
+    "start": "astro dev",
     "build": "astro check && astro build",
     "build:deno": "deno run -A npm:astro check && deno run -A npm:astro build",
     "preview": "astro preview",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "npm --prefix frontend run dev",
-    "start:front": "cd frontend && deno run -A npm:astro dev",
+    "start:front": "npm --prefix frontend run dev",
     "build": "npm --prefix frontend run build",
     "preview": "npm --prefix frontend run preview",
     "astro": "npm --prefix frontend run astro",
     "start:back": "deno run --allow-net --watch ./backend/main.ts",
-    "start": "npm-run-all --parallel start:back start:front"
+    "start": "npm-run-all --parallel start:back start:front",
+    "inst": "npm install && npm --prefix frontend install"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"


### PR DESCRIPTION
Deno não rodou bem astro e vue. Por isso, atualizei o devcontainer para ter node LTS (no momento, versão 20).

Alterei as ações para que frontend sempre seja executado pelo npm/node.

Para acessar back e front, precisei alterar o host de ambas as aplicações para "0.0.0.0".

Quando abrir o container pela primeira vez:
_npm run inst_

Esse comando vai instalar as dependências da raiz (executar comandos em paralelo) e do front.

Quando quiser iniciar ambas as aplicações:
_npm run start_

Ao fazer CTRL+C, interromperá ambas as aplicações.
